### PR TITLE
Add JUnit test skeleton for Parser class

### DIFF
--- a/src/test/java/seedu/planitarium/parser/ParserTest.java
+++ b/src/test/java/seedu/planitarium/parser/ParserTest.java
@@ -1,0 +1,33 @@
+package seedu.planitarium.parser;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class ParserTest {
+
+    @Test
+    void parseDelimitedTerm() {
+    }
+
+    @Test
+    void parseKeyword() {
+    }
+
+    @Test
+    void parseName() {
+    }
+
+    @Test
+    void parseUserIndex() {
+    }
+
+    @Test
+    void parseIncome() {
+    }
+
+    @Test
+    void parseExpenditure() {
+    }
+}

--- a/src/test/java/seedu/planitarium/parser/ParserTest.java
+++ b/src/test/java/seedu/planitarium/parser/ParserTest.java
@@ -7,8 +7,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 class ParserTest {
 
+    Parser p = new Parser();
+
     @Test
-    void parseDelimitedTerm() {
+    void parseDelimitedTerm_getDelimitedToken_success() {
+        String input1 = "";
     }
 
     @Test


### PR DESCRIPTION
This PR implements only the skeleton for JUnit testing the Parser class and provides the naming convention to be followed.